### PR TITLE
[iOS] Add capability to manage game assets from mobile and desktop devices

### DIFF
--- a/Assets/Editor.meta
+++ b/Assets/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f582abbffd61c47cbb1588b814e6e2e6
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/iOSPostBuild.meta
+++ b/Assets/Editor/iOSPostBuild.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a429a91723ac6420381a53f1c0913393
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Editor/iOSPostBuild/iOSPostBuildScript.cs
+++ b/Assets/Editor/iOSPostBuild/iOSPostBuildScript.cs
@@ -1,0 +1,26 @@
+using UnityEditor;
+using UnityEditor.Callbacks;
+using UnityEditor.iOS.Xcode;
+using System.IO;
+
+public class iOSPostProcess
+{
+    [PostProcessBuild]
+    public static void OnPostProcessBuild(BuildTarget target, string pathToBuiltProject)
+    {
+        if (target == BuildTarget.iOS)
+        {
+            string plistPath = Path.Combine(pathToBuiltProject, "Info.plist");
+            PlistDocument plist = new PlistDocument();
+            plist.ReadFromFile(plistPath);
+
+            PlistElementDict rootDict = plist.root;
+
+            // Add your custom key-value pairs here
+            rootDict.SetBoolean("UISupportsDocumentBrowser", true);
+            rootDict.SetBoolean("UIFileSharingEnabled", true);
+
+            File.WriteAllText(plistPath, plist.WriteToString());
+        }
+    }
+}

--- a/Assets/Editor/iOSPostBuild/iOSPostBuildScript.cs.meta
+++ b/Assets/Editor/iOSPostBuild/iOSPostBuildScript.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 91eaebbb74ee4418b9b27273a9d21d45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Add iOSPostBuildScript, which runs after iOS project build process.
Added two properties to Xcode's Info.Plist:
- [UISupportsDocumentBrowser](https://developer.apple.com/documentation/bundleresources/information_property_list/uisupportsdocumentbrowser): allow user to browse and manage files in Files app
- [UIFileSharingEnabled](https://developer.apple.com/documentation/bundleresources/information_property_list/uifilesharingenabled): allow users to transfer files from desktop via iTunes or finder.

![IMG_5970](https://github.com/VoxelBoy/MobileUO/assets/1281311/09279a51-f9b3-4691-8509-921c7335d1e4)
![IMG_5971](https://github.com/VoxelBoy/MobileUO/assets/1281311/15148ee4-3c7c-416f-bf23-315991e2fead)
![截圖 2024-07-01 下午12 08 09](https://github.com/VoxelBoy/MobileUO/assets/1281311/b79c4209-e040-4d74-ac7c-501b3067218d)


