### PR TITLE
[CS] SoundsLoader: Fix missing music issue

### DIFF
--- a/Assets/Scripts/ClassicUO/src/IO/Resources/SoundsLoader.cs
+++ b/Assets/Scripts/ClassicUO/src/IO/Resources/SoundsLoader.cs
@@ -25,9 +25,11 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Text.RegularExpressions;
 using ClassicUO.Data;
 using ClassicUO.Game;
 using ClassicUO.IO.Audio;
+using ClassicUO.Utility.Logging;
 
 namespace ClassicUO.IO.Resources
 {
@@ -263,12 +265,53 @@ namespace ClassicUO.IO.Resources
             if (splits.Length < 2 || splits.Length > 3) return false;
 
             int index = int.Parse(splits[0]);
-            string name = splits[1].Trim();
+
+            // check if name exists as file, ignoring case since UO isn't consistent with file case (necessary for *nix)
+            // also, not every filename in Config.txt has a file extension, so let's strip it out just in case.
+            string name = GetTrueFileName(Path.GetFileNameWithoutExtension(splits[1]));
+
             bool doesLoop = splits.Length == 3 && splits[2] == "loop";
 
             songData = new Tuple<int, string, bool>(index, name, doesLoop);
 
             return true;
+        }
+
+        /// <summary>
+        ///     Returns true filename from name, ignoring case since UO isn't consistent with file case (necessary for *nix)
+        /// </summary>
+        /// <param name="name">The filename from the music Config.txt</param>
+        /// <returns>a string with the true case sensitive filename</returns>
+        private static string GetTrueFileName(string name)
+        {
+            // don't worry about subdirectories, we'll recursively search them all
+            string dir = UOFileManager.GetUOFilePath(@"Music");
+
+            // Enumerate all files in the directory, using the file name as a pattern
+            // This will list all case variants of the filename even on file systems that
+            // are case sensitive.
+            Regex  pattern = new Regex($"^{name}.mp3", RegexOptions.IgnoreCase);
+            //string[] fileList = Directory.GetFiles(dir, "*.mp3", SearchOption.AllDirectories).Where(path => pattern.IsMatch(Path.GetFileName(path))).ToArray();
+            string[] fileList = Directory.GetFiles(dir, "*.mp3", SearchOption.AllDirectories);
+            fileList = Array.FindAll(fileList, path => pattern.IsMatch(Path.GetFileName(path)));
+
+            if (fileList != null && fileList.Length != 0)
+            {
+                if (fileList.Length > 1)
+                {
+                    // More than one file with the same name but different case spelling found
+                    Log.Warn($"Ambiguous File reference for {name}. More than one file found with different spellings.");
+                }
+
+                Log.Debug($"Loading music:\t\t{fileList[0]}");
+
+                return Path.GetFileName(fileList[0]);
+            }
+            
+            // If we've made it this far, there is no file with that name, regardless of case spelling
+            // return name and GetMusic will fail gracefully (play nothing)
+            Log.Warn($"No File found known as {name}");
+            return name;
         }
 
         private bool TryGetMusicData(int index, out string name, out bool doesLoop)


### PR DESCRIPTION
Hi @VoxelBoy,

I slightly modified patch from ClassicUO repo ([issue](https://github.com/ClassicUO/ClassicUO/issues/1323)). ClassicUO used a new path utility that's not exist in this repo, so I used UOFileManager.GetUOFilePath to find path to Music folder.


Please help to review this PR, thanks.
